### PR TITLE
Breaking Change: MQTT now transfers data points instead of json, Web Interface + API added

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -1,6 +1,6 @@
 unsigned long uptime, seconds;
 bool holdingregisters = true;
-const char buildversion[]="v1.3.0Helge";
+const char buildversion[]="v2.0.0";
 
 #define EE_START_ADDR 0x00 // start address of values stored in the eeprom
 #define EE_INIT_STATE_SIZE 4

--- a/include/growattInterface.h
+++ b/include/growattInterface.h
@@ -11,6 +11,7 @@ class growattIF {
 #define SLAVE_ID        1         // Default slave ID of Growatt
 #define MODBUS_RATE     9600      // Modbus speed of Growatt, do not change
 
+#define TMP_BUFFER_SIZE  50 // used for String Operations
   private:
     ModbusMaster growattInterface;
     SoftwareSerial *serial;
@@ -24,7 +25,7 @@ class growattIF {
     int overflow;
 
 
-    uint8_t lastModbusTransmissionStatus;
+    
     #define INPUT_REGISTER_COUNT 128
     uint16_t inputRegisterContents[INPUT_REGISTER_COUNT];
     #define HOLDING_REGISTER_COUNT 128
@@ -160,8 +161,12 @@ class growattIF {
     uint8_t ReadHoldingRegisters();
     void PublishHoldingRegisters(PubSubClient * mqtt,char * topicRoot);
 
-    String sendModbusError(uint8_t result);
-    
+    const char * getModbusErrorString(uint8_t errorCode);
+    const char * getInverterStatusString(uint8_t statusCode);
+
+    uint8_t lastModbusTransmissionStatus;    
+    char unknownModbusExceptionString[TMP_BUFFER_SIZE];    
+    char unknownInverterStatusString[TMP_BUFFER_SIZE];    
 
     // Error codes
     static const uint8_t Success    = 0x00;

--- a/include/growattInterface.h
+++ b/include/growattInterface.h
@@ -2,6 +2,7 @@
 #define GROWATTINTERFACE_H
 
 #include "Arduino.h"
+#include <PubSubClient.h>     // MQTT support
 #include <ModbusMaster.h>         // Modbus master library for ESP8266
 #include <SoftwareSerial.h>       // Leave the main serial line (USB) for debugging and flashing
 
@@ -22,35 +23,145 @@ class growattIF {
     int setcounter = 0;
     int overflow;
 
+
+    uint8_t lastModbusTransmissionStatus;
+    #define INPUT_REGISTER_COUNT 128
+    uint16_t inputRegisterContents[INPUT_REGISTER_COUNT];
+    #define HOLDING_REGISTER_COUNT 128
+    uint16_t holdingRegisterContents[HOLDING_REGISTER_COUNT];
+
+    
+    #define WEB_RESPONSE_SIZE 8192
+    char webResponse[WEB_RESPONSE_SIZE];
+
+    #define WEB_MODBUS_RESPONSE_SIZE 8192
+    char webModbusResponse[WEB_MODBUS_RESPONSE_SIZE];
+
     struct modbus_input_registers
     {
-      int status;
-      float solarpower, pv1voltage, pv1current, pv1power, pv2voltage, pv2current, pv2power, outputpower, gridfrequency, gridvoltage;
-      float energytoday, energytotal, totalworktime, pv1energytoday, pv1energytotal, pv2energytoday, pv2energytotal, opfullpower;
-      float tempinverter, tempipm, tempboost;
-      int ipf, realoppercent, deratingmode, faultcode, faultbitcode, warningbitcode;
+      int   status; 
+      float solarpower;
+      float pv1voltage;
+      float pv1current;
+      float pv1power;
+      float pv2voltage;
+      float pv2current;
+      float pv2power;
+      float outputpower;
+      float gridfrequency;
+      float gridvoltage;
+      float energytoday;
+      float energytotal; 
+      float totalworktime;
+      float pv1energytoday;
+      float pv1energytotal;
+      float pv2energytoday;
+      float pv2energytotal;
+      float opfullpower;
+      float tempinverter;
+      float tempipm;
+      float tempboost;
+      int   ipf;
+      int   realoppercent;
+      int   deratingmode;
+      int   faultcode;
+      int   faultbitcode; 
+      int   warningbitcode;
     };
     struct modbus_input_registers modbusdata;
 
+
+#define STR_STATUS          "status"          
+#define STR_SOLARPOWER      "solarpower"      
+#define STR_PV1VOLTAGE      "pv1voltage"        
+#define STR_PV1CURRENT      "pv1current"        
+#define STR_PV1POWER        "pv1power"            
+#define STR_PV2VOLTAGE      "pv2voltage"        
+#define STR_PV2CURRENT      "pv2current"          
+#define STR_PV2POWER        "pv2power"            
+#define STR_OUTPUTPOWER     "outputpower"   
+#define STR_GRIDFREQUENCY   "gridfrequency" 
+#define STR_GRIDVOLTAGE     "gridvoltage"   
+#define STR_ENERGYTODAY     "energytoday"   
+#define STR_ENERGYTOTAL     "energytotal"     
+#define STR_TOTALWORKTIME   "totalworktime"     
+#define STR_PV1ENERGYTODAY  "pv1energytoday"    
+#define STR_PV1ENERGYTOTAL  "pv1energytotal"    
+#define STR_PV2ENERGYTODAY  "pv2energytoday"  
+#define STR_PV2ENERGYTOTAL  "pv2energytotal"
+#define STR_OPFULLPOWER     "opfullpower"     
+#define STR_TEMPINVERTER    "tempinverter"    
+#define STR_TEMPIPM         "tempipm"         
+#define STR_TEMPBOOST       "tempboost"         
+#define STR_IPF             "ipf"             
+#define STR_REALOPPERCENT   "realoppercent"   
+#define STR_DERATINGMODE    "deratingmode"    
+#define STR_FAULTCODE       "faultcode"         
+#define STR_FAULTBITCODE    "faultbitcode"        
+#define STR_WARNINGBITCODE  "warningbitcode"      
+
     struct modbus_holding_registers
     {
-      int enable, safetyfuncen, maxoutputactivepp, maxoutputreactivepp, modul;
-      float  maxpower, voltnormal, startvoltage, gridvoltlowlimit, gridvolthighlimit, gridfreqlowlimit, gridfreqhighlimit, gridvoltlowconnlimit, gridvolthighconnlimit, gridfreqlowconnlimit, gridfreqhighconnlimit;
-      char firmware[7], controlfirmware[7];
-      char serial[11];
+      int   enable                ; 
+      int   safetyfuncen          ; 
+      int   maxoutputactivepp     ;
+      int   maxoutputreactivepp   ; 
+      int   modul                 ;
+      float maxpower              ;
+      float voltnormal            ;
+      float startvoltage          ;
+      float gridvoltlowlimit      ;
+      float gridvolthighlimit     ; 
+      float gridfreqlowlimit      ;
+      float gridfreqhighlimit     ;
+      float gridvoltlowconnlimit  ;
+      float gridvolthighconnlimit ; 
+      float gridfreqlowconnlimit  ;
+      float gridfreqhighconnlimit ;
+      char  firmware[7]           ;
+      char  controlfirmware[7]    ;
+      char  serial[11]            ;
     };
-
     struct modbus_holding_registers modbussettings;
+
+#define STR_ENABLE                "enable"
+#define STR_SAFETYFUNCEN          "safetyfuncen"
+#define STR_MAXOUTPUTACTIVEPP     "maxoutputactivepp"
+#define STR_MAXOUTPUTREACTIVEPP   "maxoutputreactivepp"
+#define STR_MODUL                 "modul"
+#define STR_MAXPOWER              "maxpower"
+#define STR_VOLTNORMAL            "voltnormal"
+#define STR_STARTVOLTAGE          "startvoltage"
+#define STR_GRIDVOLTLOWLIMIT      "gridvoltlowlimit"
+#define STR_GRIDVOLTHIGHLIMIT     "gridvolthighlimit"
+#define STR_GRIDFREQLOWLIMIT      "gridfreqlowlimit"
+#define STR_GRIDFREQHIGHLIMIT     "gridfreqhighlimit"
+#define STR_GRIDVOLTLOWCONNLIMIT  "gridvoltlowconnlimit "
+#define STR_GRIDVOLTHIGHCONNLIMIT "gridvolthighconnlimit"
+#define STR_GRIDFREQLOWCONNLIMIT  "gridfreqlowconnlimit "
+#define STR_GRIDFREQHIGHCONNLIMIT "gridfreqhighconnlimit"
+#define STR_FIRMWARE              "firmware"
+#define STR_CONTROLFIRMWARE       "controlfirmware"
+#define STR_SERIAL                "serial"
+
+
   public:
     growattIF(int _PinMAX485_RE_NEG, int _PinMAX485_DE, int _PinMAX485_RX, int _PinMAX485_TX);
     void initGrowatt();
     uint8_t writeRegister(uint16_t reg, uint16_t message);
     uint16_t readRegister(uint16_t reg);
+
+    const char * getWebStatusPage(unsigned long uptime);
+    const char * getWebModbuStatusPage();
+
     uint8_t ReadInputRegisters();
-    void InputRegistersToJson(char* json);
+    void PublishInputRegisters(PubSubClient * mqtt,char * topicRoot);
+
     uint8_t ReadHoldingRegisters();
-    void HoldingRegistersToJson(char* json);
+    void PublishHoldingRegisters(PubSubClient * mqtt,char * topicRoot);
+
     String sendModbusError(uint8_t result);
+    
 
     // Error codes
     static const uint8_t Success    = 0x00;

--- a/include/settings.h
+++ b/include/settings.h
@@ -1,16 +1,19 @@
 //#define DEBUG_SERIAL    
 //#define DEBUG_MQTT       
 #define useModulPower   
-#define AHTXX_SENSOR               // add support for the AHT10, AHT15, AHT20 sensor family 
+//#define AHTXX_SENSOR               // add support for the AHT10, AHT15, AHT20 sensor family 
+
+#define ENABLE_WEBAPI_POST               // enables Inverter Control via Web API
+
 
 #define SERIAL_RATE     115200    // Serial speed for status info
-#define MAX485_DE       16        // D0, DE pin on the TTL to RS485 converter
+#define MAX485_DE       16         // D0, DE pin on the TTL to RS485 converter
 #define MAX485_RE_NEG   13        // D7, RE pin on the TTL to RS485 converter
 #define MAX485_RX       14        // D5, RO pin on the TTL to RS485 converter
 #define MAX485_TX       12        // D6, DI pin on the TTL to RS485 converter
 #define STATUS_LED      2         // Status LED on the Wemos D1 mini (D4)
-#define SCL_PIN         5
-#define SDA_PIN         4
+#define SCL_PIN         5         // D1/SCL to Pin SCL on AHT Sensor
+#define SDA_PIN         4         // D2/SDA to Pin SDA on AHT Sensor
 #define UPDATE_MODBUS   10         // 1: modbus device is read every second and data are anounced via mqtt
 #define UPDATE_STATUS   30        // 10: status mqtt message is sent every 10 seconds
 #define WIFICHECK       1           // 1: every second
@@ -20,7 +23,7 @@
 const char mqtt_server[] = "";    // MQTT server
 const int mqtt_server_port = 1883;             // MQTT server port, default is 1883
 const char mqtt_user[] = "none";               // MQTT userid
-const char mqtt_password[] = "none";        // MQTT password
+const char mqtt_password[] = "nome";        // MQTT password
 const char clientID[] = "growatt";       // MQTT client ID
 const char topicRootStart[] = "growatt";      // MQTT root topic for the device, + client ID
 

--- a/src/growattInterface.cpp
+++ b/src/growattInterface.cpp
@@ -1,5 +1,6 @@
 #include "growattInterface.h"
 
+
 growattIF::growattIF(int _PinMAX485_RE_NEG, int _PinMAX485_DE, int _PinMAX485_RX, int _PinMAX485_TX) {
   PinMAX485_RE_NEG = _PinMAX485_RE_NEG;
   PinMAX485_DE = _PinMAX485_DE;
@@ -48,15 +49,128 @@ void growattIF::postTransmission() {
   digitalWrite(PinMAX485_DE, 0);
 }
 
+const char * growattIF::getWebStatusPage(unsigned long uptime)
+{
+
+#define WEB_LINE_SIZE  100
+char webLineBuffer[WEB_LINE_SIZE];
+
+  strcpy(webResponse,  "<html><head><title>Growatt</title><meta http-equiv=\"refresh\" content=\"10\"></head><body><h2>Growatt Solar Inverter to MQTT Gateway </h2>");
+
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "Last Modbus Transmission Status: %i - ",lastModbusTransmissionStatus ); strcat(webResponse, webLineBuffer);
+  strcat(webResponse, sendModbusError(lastModbusTransmissionStatus).c_str());
+
+
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<table><tr><td><table><tr><td>Uptime </td><td> %lu days %lu:%02lu:%02lu h</td></tr>", uptime/(3600*24),(uptime/3600)%3600,(uptime/60)%60,uptime%60); strcat(webResponse, webLineBuffer);
+
+  //Modbus Status
+
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_STATUS         "</td><td> %i      </td></tr>" , modbusdata.status         ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_OUTPUTPOWER    "</td><td> %3.2f W</td></tr>"  , modbusdata.outputpower    ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_ENERGYTODAY    "</td><td> %3.3f kWh</td></tr>", modbusdata.energytoday    ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_ENERGYTOTAL    "</td><td> %3.2f kWh</td></tr>", modbusdata.energytotal    ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_SOLARPOWER     "</td><td> %3.2f W</td></tr>"  , modbusdata.solarpower     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV1ENERGYTODAY "</td><td> %3.2f kWh</td></tr>", modbusdata.pv1energytoday ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV1ENERGYTOTAL "</td><td> %3.2f kWh</td></tr>", modbusdata.pv1energytotal ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV1POWER       "</td><td> %3.2f W</td></tr>"  , modbusdata.pv1power       ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV1VOLTAGE     "</td><td> %3.2f V</td></tr>"  , modbusdata.pv1voltage     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV1CURRENT     "</td><td> %3.2f A</td></tr>"  , modbusdata.pv1current     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV2ENERGYTODAY "</td><td> %3.2f kWh</td></tr>", modbusdata.pv2energytoday ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV2ENERGYTOTAL "</td><td> %3.2f kWh</td></tr>", modbusdata.pv2energytotal ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV2POWER       "</td><td> %3.2f W</td></tr>"  , modbusdata.pv2power       ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV2VOLTAGE     "</td><td> %3.2f V</td></tr>"  , modbusdata.pv2voltage     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV2CURRENT     "</td><td> %3.2f A</td></tr>"  , modbusdata.pv2current     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDFREQUENCY  "</td><td> %3.2f Hz</td></tr>" , modbusdata.gridfrequency  ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDVOLTAGE    "</td><td> %3.2f V</td></tr>"  , modbusdata.gridvoltage    ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TOTALWORKTIME  "</td><td> %3.2f s</td></tr>"  , modbusdata.totalworktime  ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_OPFULLPOWER    "</td><td> %3.2f </td></tr>"   , modbusdata.opfullpower    ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TEMPINVERTER   "</td><td> %3.2f C</td></tr>"  , modbusdata.tempinverter   ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TEMPIPM        "</td><td> %3.2f C</td></tr>"  , modbusdata.tempipm        ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TEMPBOOST      "</td><td> %3.2f C</td></tr>"  , modbusdata.tempboost      ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_IPF            "</td><td> %i    </td></tr>"   , modbusdata.ipf            ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_REALOPPERCENT  "</td><td> %i    </td></tr>"   , modbusdata.realoppercent  ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_DERATINGMODE   "</td><td> %i    </td></tr>"   , modbusdata.deratingmode   ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_FAULTCODE      "</td><td> %i    </td></tr>"   , modbusdata.faultcode      ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_FAULTBITCODE   "</td><td> %i    </td></tr>"   , modbusdata.faultbitcode   ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_WARNINGBITCODE "</td><td> %i    </td></tr>"   , modbusdata.warningbitcode ); strcat(webResponse, webLineBuffer);
+
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "</table></td><td><table>"); strcat(webResponse, webLineBuffer);
+
+  // Modbus Settings
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_ENABLE                "</td><td> %i    </td></tr>"   , modbussettings.enable                ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_SAFETYFUNCEN          "</td><td> %i    </td></tr>"   , modbussettings.safetyfuncen          ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_MAXOUTPUTACTIVEPP     "</td><td> %i    </td></tr>"   , modbussettings.maxoutputactivepp     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_MAXOUTPUTREACTIVEPP   "</td><td> %i    </td></tr>"   , modbussettings.maxoutputreactivepp   ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_MODUL                 "</td><td> %i    </td></tr>"   , modbussettings.modul                 ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_MAXPOWER              "</td><td> %3.2f </td></tr>"   , modbussettings.maxpower              ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_VOLTNORMAL            "</td><td> %3.2f </td></tr>"   , modbussettings.voltnormal            ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_STARTVOLTAGE          "</td><td> %3.2f </td></tr>"   , modbussettings.startvoltage          ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDVOLTLOWLIMIT      "</td><td> %3.2f </td></tr>"   , modbussettings.gridvoltlowlimit      ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDVOLTHIGHLIMIT     "</td><td> %3.2f </td></tr>"   , modbussettings.gridvolthighlimit     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDFREQLOWLIMIT      "</td><td> %3.2f </td></tr>"   , modbussettings.gridfreqlowlimit      ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDFREQHIGHLIMIT     "</td><td> %3.2f </td></tr>"   , modbussettings.gridfreqhighlimit     ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDVOLTLOWCONNLIMIT  "</td><td> %3.2f </td></tr>"   , modbussettings.gridvoltlowconnlimit  ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDVOLTHIGHCONNLIMIT "</td><td> %3.2f </td></tr>"   , modbussettings.gridvolthighconnlimit ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDFREQLOWCONNLIMIT  "</td><td> %3.2f </td></tr>"   , modbussettings.gridfreqlowconnlimit  ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDFREQHIGHCONNLIMIT "</td><td> %3.2f </td></tr>"   , modbussettings.gridfreqhighconnlimit ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_FIRMWARE              "</td><td> %s    </td></tr>"   , modbussettings.firmware              ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_CONTROLFIRMWARE       "</td><td> %s    </td></tr>"   , modbussettings.controlfirmware       ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_SERIAL                "</td><td> %s    </td></tr>"   , modbussettings.serial                ); strcat(webResponse, webLineBuffer);
+
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "</table></table></body></html>"); strcat(webResponse, webLineBuffer);
+  return webResponse;
+}
+
+const char * growattIF::getWebModbuStatusPage()
+{
+
+#define WEB_LINE_SIZE  100
+char webLineBuffer[WEB_LINE_SIZE];
+
+  strcpy(webModbusResponse,  "<html><head></head><body><h2>Growatt Solar Inverter Modbus Status </h2>");
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "Last Transmission Status: %i - ",lastModbusTransmissionStatus ); strcat(webModbusResponse, webLineBuffer);
+  strcat(webModbusResponse, sendModbusError(lastModbusTransmissionStatus).c_str());
+
+  //Modbus Input Status
+  strcat(webModbusResponse,  "<h3>Input Registers</h3><table>");
+
+  for (int i = 0; i < INPUT_REGISTER_COUNT; i+=8) {
+    snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td> %03i 0x%02x </td><td>" , i,i ); strcat(webModbusResponse, webLineBuffer); 
+    for (int j = i ; j< i+8 ; j++) {
+      snprintf(webLineBuffer, WEB_LINE_SIZE, "%04x ",inputRegisterContents[j] ); strcat(webModbusResponse, webLineBuffer);
+    }
+    strcat(webModbusResponse, "</td></tr>"); 
+  }
+  strcat(webModbusResponse, "</table>"); 
+
+  //Modbus Holding Status
+  strcat(webModbusResponse,  "<h3>Holding Registers</h3><table>");
+
+  for (int i = 0; i < HOLDING_REGISTER_COUNT; i+=8) {
+    snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td> %03i 0x%02x </td><td>" , i,i ); strcat(webModbusResponse, webLineBuffer); 
+    for (int j = i ; j< i+8 ; j++) {
+      snprintf(webLineBuffer, WEB_LINE_SIZE, "%04x ",holdingRegisterContents[j] ); strcat(webModbusResponse, webLineBuffer);
+    }
+    strcat(webModbusResponse, "</td></tr>"); 
+  }
+  strcat(webModbusResponse, "</table></body></html>"); 
+
+  return webModbusResponse;
+}
+
+
+
+
 uint8_t growattIF::ReadInputRegisters() {
-  uint8_t result;
 
   ESP.wdtDisable();
-  result = growattInterface.readInputRegisters(0 * 64, 64);
+  lastModbusTransmissionStatus = growattInterface.readInputRegisters(0 * 64, 64);
   ESP.wdtEnable(1);
 
-  if (result == growattInterface.ku8MBSuccess)   
+  if (lastModbusTransmissionStatus == growattInterface.ku8MBSuccess)   
   {
+    //local Buffer for Webinterface
+    for (int i = 0*64; i< 64; i++) inputRegisterContents[i] = growattInterface.getResponseBuffer(i);
     // register 0-63
     //  Status and PV data
     modbusdata.status = growattInterface.getResponseBuffer(0);
@@ -86,16 +200,18 @@ uint8_t growattIF::ReadInputRegisters() {
   }
   else
   {
-      return result;
+      return lastModbusTransmissionStatus;
   }
   delay(10); // if not bus error occours
   // next register block
   ESP.wdtDisable();
-  result = growattInterface.readInputRegisters(1 * 64, 64);
+  lastModbusTransmissionStatus = growattInterface.readInputRegisters(1 * 64, 64);
   ESP.wdtEnable(1);
 
-  if (result == growattInterface.ku8MBSuccess) 
+  if (lastModbusTransmissionStatus == growattInterface.ku8MBSuccess) 
   { // register 64 -127
+      for (int i = 0; i< 64; i++) inputRegisterContents[i+64] = growattInterface.getResponseBuffer(i);
+
       modbusdata.pv2energytoday = ((overflow << 16) | growattInterface.getResponseBuffer(64 - 64)) * 0.1;
       modbusdata.pv2energytotal = ((growattInterface.getResponseBuffer(65 - 64) << 16) | growattInterface.getResponseBuffer(66 - 64)) * 0.1;
 
@@ -188,7 +304,7 @@ uint8_t growattIF::ReadInputRegisters() {
   }
   else
   {
-      return result;
+      return lastModbusTransmissionStatus;
   }
   
   return Success;
@@ -196,82 +312,54 @@ uint8_t growattIF::ReadInputRegisters() {
 
 #define TMP_BUFFER_SIZE  50
 
-void growattIF::InputRegistersToJson(char* json)
+void growattIF::PublishInputRegisters(PubSubClient * mqtt,char * topicData)
 {
-  // Generate the modbus MQTT message
-  char tmp_json[TMP_BUFFER_SIZE];
+  char thisTopic[TMP_BUFFER_SIZE];
+  char thisValue[TMP_BUFFER_SIZE];
 
-  strcpy(json, "{");
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"status\":%d,", modbusdata.status);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"solarpower\":%.1f,", modbusdata.solarpower);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv1voltage\":%.1f,", modbusdata.pv1voltage);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv1current\":%.1f,", modbusdata.pv1current);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv1power\":%.1f,", modbusdata.pv1power);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv2voltage\":%.1f,", modbusdata.pv2voltage);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv2current\":%.1f,", modbusdata.pv2current);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv2power\":%.1f,", modbusdata.pv2power);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"outputpower\":%.1f,", modbusdata.outputpower);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridfrequency\":%.2f,", modbusdata.gridfrequency);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridvoltage\":%.1f,", modbusdata.gridvoltage);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"energytoday\":%.1f,", modbusdata.energytoday);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"energytotal\":%.1f,", modbusdata.energytotal);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"totalworktime\":%.1f,", modbusdata.totalworktime);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv1energytoday\":%.1f,", modbusdata.pv1energytoday);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv1energytotal\":%.1f,", modbusdata.pv1energytotal);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv2energytoday\":%.1f,", modbusdata.pv2energytoday);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"pv2energytotal\":%.1f,", modbusdata.pv2energytotal);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"opfullpower\":%.1f,", modbusdata.opfullpower);
-  strcat(json, tmp_json);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_STATUS        , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%d", modbusdata.status         ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_SOLARPOWER    , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.solarpower     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV1VOLTAGE    , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv1voltage     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV1CURRENT    , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv1current     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV1POWER      , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv1power       ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV2VOLTAGE    , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv2voltage     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV2CURRENT    , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv2current     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV2POWER      , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv2power       ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_OUTPUTPOWER   , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.outputpower    ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDFREQUENCY , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.gridfrequency  ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDVOLTAGE   , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.gridvoltage    ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_ENERGYTODAY   , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.energytoday    ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_ENERGYTOTAL   , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.energytotal    ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_TOTALWORKTIME , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.totalworktime  ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV1ENERGYTODAY, topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv1energytoday ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV1ENERGYTOTAL, topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv1energytotal ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV2ENERGYTODAY, topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv2energytoday ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_PV2ENERGYTOTAL, topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.pv2energytotal ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_OPFULLPOWER   , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.opfullpower    ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_TEMPINVERTER  , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.tempinverter   ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_TEMPIPM       , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.tempipm        ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_TEMPBOOST     , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbusdata.tempboost      ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_IPF           , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%d", modbusdata.ipf            ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_REALOPPERCENT , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%d", modbusdata.realoppercent  ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_DERATINGMODE  , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%d", modbusdata.deratingmode   ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_FAULTCODE     , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%d", modbusdata.faultcode      ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_FAULTBITCODE  , topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%d", modbusdata.faultbitcode   ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_WARNINGBITCODE, topicData  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%d", modbusdata.warningbitcode ); mqtt->publish(thisTopic, thisValue);
+return;
+}
 
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"tempinverter\":%.1f,", modbusdata.tempinverter);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"tempipm\":%.1f,", modbusdata.tempipm);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"tempboost\":%.1f,", modbusdata.tempboost);
-  strcat(json, tmp_json);
 
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"ipf\":%d,", modbusdata.ipf);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"realoppercent\":%d,", modbusdata.realoppercent);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"deratingmode\":%d,", modbusdata.deratingmode);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"faultcode\":%d,", modbusdata.faultcode);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"faultbitcode\":%d,", modbusdata.faultbitcode);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"warningbitcode\":%d}", modbusdata.warningbitcode);
-  strcat(json, tmp_json);
-}  
 
   uint8_t growattIF::ReadHoldingRegisters()
   {
-    uint8_t result;
-    
     ESP.wdtDisable();
-    result = growattInterface.readHoldingRegisters(0 * 64, 64);
+    lastModbusTransmissionStatus = growattInterface.readHoldingRegisters(0 * 64, 64);
     ESP.wdtEnable(1);
 
-    if (result == growattInterface.ku8MBSuccess)
+    if (lastModbusTransmissionStatus == growattInterface.ku8MBSuccess)
     {
+       for (int i = 0; i< 64; i++) holdingRegisterContents[i] = growattInterface.getResponseBuffer(i);
+
       // register 0-63
         modbussettings.enable = growattInterface.getResponseBuffer(0);
         modbussettings.safetyfuncen = growattInterface.getResponseBuffer(1); // Safety Function Enabled
@@ -286,8 +374,8 @@ void growattIF::InputRegistersToJson(char* json)
         //  Bit8: ROCOF enable
         //  Bit9: Recover FreqDerating Mode Enable
         //  Bit10~15: Reserved
-        modbussettings.maxoutputactivepp = growattInterface.getResponseBuffer(3);   // Inverter M ax output active power percent  0-100: %, 255: not limited
-        modbussettings.maxoutputreactivepp = growattInterface.getResponseBuffer(4); // Inverter M ax output reactive power percent  0-100: %, 255: not limited
+        modbussettings.maxoutputactivepp = growattInterface.getResponseBuffer(3);   // Inverter Max output active power percent  0-100: %, 255: not limited
+        modbussettings.maxoutputreactivepp = growattInterface.getResponseBuffer(4); // Inverter Max output reactive power percent  0-100: %, 255: not limited
         modbussettings.maxpower = ((growattInterface.getResponseBuffer(6) << 16) | growattInterface.getResponseBuffer(7)) * 0.1;
         modbussettings.voltnormal = growattInterface.getResponseBuffer(8) * 0.1;
 
@@ -328,15 +416,17 @@ void growattIF::InputRegistersToJson(char* json)
     }
     else
     {
-     return result;
+     return lastModbusTransmissionStatus;
     }
     delay(10);
     ESP.wdtDisable();
-    result = growattInterface.readHoldingRegisters(1 * 64, 64);
+    lastModbusTransmissionStatus = growattInterface.readHoldingRegisters(1 * 64, 64);
     ESP.wdtEnable(1);
 
-    if (result == growattInterface.ku8MBSuccess)
+    if (lastModbusTransmissionStatus == growattInterface.ku8MBSuccess)
     {
+     for (int i = 0; i< 64; i++) holdingRegisterContents[i+64] = growattInterface.getResponseBuffer(i);
+
      // register 64 -127
       modbussettings.gridvoltlowconnlimit = growattInterface.getResponseBuffer(64 - 64) * 0.1;
       modbussettings.gridvolthighconnlimit = growattInterface.getResponseBuffer(65 - 64) * 0.1;
@@ -347,7 +437,7 @@ void growattIF::InputRegistersToJson(char* json)
     }
     else
     {
-      return result;
+      return lastModbusTransmissionStatus;
     }
     /*{ // register 128-191
         //          //          modbussettings.modul = growattInterface.getResponseBuffer(130 - 128);
@@ -360,59 +450,40 @@ void growattIF::InputRegistersToJson(char* json)
     return Success;
 }
 
-void growattIF::HoldingRegistersToJson(char *json)
+void growattIF::PublishHoldingRegisters(PubSubClient * mqtt,char * topicSettings)
 {
-  
-  char tmp_json[TMP_BUFFER_SIZE];
+  char thisTopic[TMP_BUFFER_SIZE];
+  char thisValue[TMP_BUFFER_SIZE];
 
-  // Generate the modbus MQTT message
-  strcpy(json, "{");
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"enable\":%d,", modbussettings.enable);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"safetyfuncen\":%d,", modbussettings.safetyfuncen);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"maxoutputactivepp\":%d,", modbussettings.maxoutputactivepp);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"maxoutputreactivepp\":%d,", modbussettings.maxoutputreactivepp);
-  strcat(json, tmp_json);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_ENABLE               , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%i", modbussettings.enable                ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_SAFETYFUNCEN         , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%i", modbussettings.safetyfuncen          ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_MAXOUTPUTACTIVEPP    , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%i", modbussettings.maxoutputactivepp     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_MAXOUTPUTREACTIVEPP  , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%i", modbussettings.maxoutputreactivepp   ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_MODUL                , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%i", modbussettings.modul                 ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_MAXPOWER             , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.maxpower              ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_VOLTNORMAL           , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.voltnormal            ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_STARTVOLTAGE         , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.startvoltage          ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDVOLTLOWLIMIT     , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridvoltlowlimit      ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDVOLTHIGHLIMIT    , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridvolthighlimit     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDFREQLOWLIMIT     , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridfreqlowlimit      ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDFREQHIGHLIMIT    , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridfreqhighlimit     ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDVOLTLOWCONNLIMIT , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridvoltlowconnlimit  ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDVOLTHIGHCONNLIMIT, topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridvolthighconnlimit ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDFREQLOWCONNLIMIT , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridfreqlowconnlimit  ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_GRIDFREQHIGHCONNLIMIT, topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%f", modbussettings.gridfreqhighconnlimit ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_FIRMWARE             , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%s", modbussettings.firmware              ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_CONTROLFIRMWARE      , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%s", modbussettings.controlfirmware       ); mqtt->publish(thisTopic, thisValue);
+snprintf(thisTopic, TMP_BUFFER_SIZE, "%s/" STR_SERIAL               , topicSettings  ) ; snprintf(thisValue, TMP_BUFFER_SIZE, "%s", modbussettings.serial                ); mqtt->publish(thisTopic, thisValue);
 
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"maxpower\":%.1f,", modbussettings.maxpower);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"voltnormal\":%.1f,", modbussettings.voltnormal);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"startvoltage\":%.1f,", modbussettings.startvoltage);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridvoltlowlimit\":%.1f,", modbussettings.gridvoltlowlimit);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridvolthighlimit\":%.1f,", modbussettings.gridvolthighlimit);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridfreqlowlimit\":%.1f,", modbussettings.gridfreqlowlimit);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridfreqhighlimit\":%.1f,", modbussettings.gridfreqhighlimit);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridvoltlowconnlimit\":%.1f,", modbussettings.gridvoltlowconnlimit);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridvolthighconnlimit\":%.1f,", modbussettings.gridvolthighconnlimit);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridfreqlowconnlimit\":%.1f,", modbussettings.gridfreqlowconnlimit);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"gridfreqhighconnlimit\":%.1f,", modbussettings.gridfreqhighconnlimit);
-  strcat(json, tmp_json);
-
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"firmware\":\"%s\",", modbussettings.firmware);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"controlfirmware\":\"%s\",", modbussettings.controlfirmware);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"serial\":\"%s\",", modbussettings.serial);
-  strcat(json, tmp_json);
-  snprintf(tmp_json, TMP_BUFFER_SIZE, "\"modulPower\":\"%04X\"}", modbussettings.modul);
-  strcat(json, tmp_json);
+return;
 }
-
-
   String growattIF::sendModbusError(uint8_t result)
   {
     String message = "";
+    if (result == growattInterface.ku8MBSuccess)
+    {
+        message = "Success";
+    }
     if (result == growattInterface.ku8MBIllegalFunction)
     {
         message = "Illegal function";

--- a/src/growattInterface.cpp
+++ b/src/growattInterface.cpp
@@ -61,12 +61,14 @@ char webLineBuffer[WEB_LINE_SIZE];
   strcat(webResponse, getModbusErrorString(lastModbusTransmissionStatus));
 
 
-  snprintf(webLineBuffer, WEB_LINE_SIZE, "<table><tr><td><table><tr><td>Uptime </td><td> %lu days %lu:%02lu:%02lu h</td></tr>", uptime/(3600*24),(uptime/3600)%3600,(uptime/60)%60,uptime%60); strcat(webResponse, webLineBuffer);
-
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<table><tr><td><table><tr><td>Interface Uptime: </td><td> %lu days %lu:%02lu:%02lu h</td></tr>", uptime/(3600*24),uptime%(3600*24)/3600,(uptime/60)%60,uptime%60); strcat(webResponse, webLineBuffer);
+  unsigned long t = (unsigned long)modbusdata.totalworktime;
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>Total Inverter Work Time: </td><td> %lu days %lu:%02lu:%02lu h </td></tr>", t/(3600*24),t%(3600*24)/3600,(t/60)%60,t%60 ); strcat(webResponse, webLineBuffer);
+  strcat(webResponse, "<tr><td>-------------</td><td>");
   //Modbus Status
 
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_STATUS         "</td><td> %s </td></tr>"      , getInverterStatusString(modbusdata.status) ); strcat(webResponse, webLineBuffer);
-  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_OUTPUTPOWER    "</td><td> %3.2f W</td></tr>"  , modbusdata.outputpower    ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_OUTPUTPOWER    "</td><td><b> %3.2f W</b></td></tr>"  , modbusdata.outputpower    ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_ENERGYTODAY    "</td><td> %3.3f kWh</td></tr>", modbusdata.energytoday    ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_ENERGYTOTAL    "</td><td> %3.2f kWh</td></tr>", modbusdata.energytotal    ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_SOLARPOWER     "</td><td> %3.2f W</td></tr>"  , modbusdata.solarpower     ); strcat(webResponse, webLineBuffer);
@@ -82,11 +84,11 @@ char webLineBuffer[WEB_LINE_SIZE];
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_PV2CURRENT     "</td><td> %3.2f A</td></tr>"  , modbusdata.pv2current     ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDFREQUENCY  "</td><td> %3.2f Hz</td></tr>" , modbusdata.gridfrequency  ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_GRIDVOLTAGE    "</td><td> %3.2f V</td></tr>"  , modbusdata.gridvoltage    ); strcat(webResponse, webLineBuffer);
-  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TOTALWORKTIME  "</td><td> %3.2f s</td></tr>"  , modbusdata.totalworktime  ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_OPFULLPOWER    "</td><td> %3.2f </td></tr>"   , modbusdata.opfullpower    ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TEMPINVERTER   "</td><td> %3.2f C</td></tr>"  , modbusdata.tempinverter   ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TEMPIPM        "</td><td> %3.2f C</td></tr>"  , modbusdata.tempipm        ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TEMPBOOST      "</td><td> %3.2f C</td></tr>"  , modbusdata.tempboost      ); strcat(webResponse, webLineBuffer);
+  snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_TOTALWORKTIME  "</td><td> %3.2f s</td></tr>"  , modbusdata.totalworktime  ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_IPF            "</td><td> %i    </td></tr>"   , modbusdata.ipf            ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_REALOPPERCENT  "</td><td> %i    </td></tr>"   , modbusdata.realoppercent  ); strcat(webResponse, webLineBuffer);
   snprintf(webLineBuffer, WEB_LINE_SIZE, "<tr><td>" STR_DERATINGMODE   "</td><td> %i    </td></tr>"   , modbusdata.deratingmode   ); strcat(webResponse, webLineBuffer);
@@ -143,9 +145,9 @@ char webLineBuffer[WEB_LINE_SIZE];
     //ASCII values
     strcat(webModbusResponse, " ");
     for (int j = i ; j< i+8 ; j++) {
-      uint8_t low,high;
-      low = inputRegisterContents[j]&0xff;
-      high = inputRegisterContents[j]<<8;
+      uint16_t low,high;
+      high = inputRegisterContents[j]&0xff;
+      low = inputRegisterContents[j]>>8;
       snprintf(webLineBuffer, WEB_LINE_SIZE, "%c%c", low > 31 && low < 127 ? low:46, high > 31 && high < 127 ? high:46);
       strcat(webModbusResponse, webLineBuffer);
     }
@@ -165,9 +167,9 @@ char webLineBuffer[WEB_LINE_SIZE];
     //ASCII values
     strcat(webModbusResponse, " ");
     for (int j = i ; j< i+8 ; j++) {
-      uint8_t low,high;
-      low = inputRegisterContents[j]&0xff;
-      high = inputRegisterContents[j]<<8;
+      uint16_t low,high;
+      high = holdingRegisterContents[j]&0xff;
+      low = holdingRegisterContents[j]>>8;
       snprintf(webLineBuffer, WEB_LINE_SIZE, "%c%c", low > 31 && low < 127 ? low:46, high > 31 && high < 127 ? high:46);
       strcat(webModbusResponse, webLineBuffer);
     }

--- a/src/growattmain.cpp
+++ b/src/growattmain.cpp
@@ -81,10 +81,9 @@ void ReadInputRegisters()
   else 
   {
     Serial.print(F("Error: "));
-    String message = growattInterface.sendModbusError(result);
-    Serial.println(message);
+    Serial.println(growattInterface.getModbusErrorString(result));
     snprintf(topic, MAX_ROOT_TOPIC_LENGTH , "%s/error", topicRoot);
-    mqtt.publish(topic, message.c_str());
+    mqtt.publish(topic, growattInterface.getModbusErrorString(result));
     delay(5);
   }
   digitalWrite(STATUS_LED, 1);
@@ -108,11 +107,9 @@ void ReadHoldingRegisters()
   else
   {
     Serial.print(F("Error: "));
-    String message;
-    message = growattInterface.sendModbusError(result);
-    Serial.println(message);
+    Serial.println(growattInterface.getModbusErrorString(result));
     snprintf(topic, MAX_ROOT_TOPIC_LENGTH, "%s/error", topicRoot);
-    mqtt.publish(topic, message.c_str());
+    mqtt.publish(topic, growattInterface.getModbusErrorString(result));
     delay(5);
   }
   digitalWrite(STATUS_LED, 1);
@@ -246,7 +243,7 @@ void callback(char *topic, byte *payload, unsigned int length)
       }
       else
       {
-        snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.sendModbusError(result).c_str());
+        snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.getModbusErrorString(result));
         snprintf(rootTopic, MAX_ROOT_TOPIC_LENGTH, "%s/error", topicRoot);
         mqtt.publish(rootTopic, json);
       }
@@ -260,7 +257,7 @@ void callback(char *topic, byte *payload, unsigned int length)
         }
         else
         {
-          snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.sendModbusError(result).c_str());
+          snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.getModbusErrorString(result));
           snprintf(rootTopic, MAX_ROOT_TOPIC_LENGTH, "%s/error", topicRoot);
           mqtt.publish(rootTopic, json);
         }
@@ -277,7 +274,7 @@ void callback(char *topic, byte *payload, unsigned int length)
     }
     else
     {
-      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.sendModbusError(result).c_str());
+      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.getModbusErrorString(result));
       snprintf(rootTopic, MAX_ROOT_TOPIC_LENGTH, "%s/error", topicRoot);
       mqtt.publish(rootTopic, json);
     }
@@ -293,7 +290,7 @@ void callback(char *topic, byte *payload, unsigned int length)
     }
     else
     {
-      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.sendModbusError(result).c_str());
+      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.getModbusErrorString(result));
       snprintf(rootTopic, MAX_ROOT_TOPIC_LENGTH, "%s/error", topicRoot);
       mqtt.publish(rootTopic, json);
     }
@@ -318,7 +315,7 @@ void callback(char *topic, byte *payload, unsigned int length)
     }
     else
     {
-      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.sendModbusError(result).c_str());
+      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.getModbusErrorString(result).c_str());
       snprintf(rootTopic, MAX_ROOT_TOPIC_LENGTH, "%s/error", topicRoot);
       mqtt.publish(rootTopic, json);
     }

--- a/src/growattmain.cpp
+++ b/src/growattmain.cpp
@@ -315,7 +315,7 @@ void callback(char *topic, byte *payload, unsigned int length)
     }
     else
     {
-      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.getModbusErrorString(result).c_str());
+      snprintf(json, MAX_JSON_TOPIC_LENGTH, "last trasmition has faild with: %s", growattInterface.getModbusErrorString(result));
       snprintf(rootTopic, MAX_ROOT_TOPIC_LENGTH, "%s/error", topicRoot);
       mqtt.publish(rootTopic, json);
     }


### PR DESCRIPTION
Hello,
I added some features to the project:
- Web page with Inverter status and settings at /
- Web page with hex-readout of all Modbus registers at /modbus
- API endpoints to limit inverter power or switch on/of
- MQTT data schema redesign. Single json object splitted up into individual data channels
- the pinout description in README.md synced with configuration in settings.h
- some typos fixed and documentation updated
